### PR TITLE
typestability and compile-time improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ QuadGK = "2.4"
 RecipesBase = "<0.8, 0.8, 1.0"
 Roots = "<0.9, 1.0"
 StatsBase = "0.33"
-TotalLeastSquares = "0.1.2, 1.0"
+TotalLeastSquares = "1.7.2"
 julia = "1.6"
 
 [extras]

--- a/src/ControlSystemIdentification.jl
+++ b/src/ControlSystemIdentification.jl
@@ -164,7 +164,7 @@ Predict AR model
 """
 function predict(G::ControlSystems.TransferFunction, y)
     _, a, _, _ = params(G)
-    yr, A = getARregressor(time1(output(y)), length(a))
+    yr, A = getARregressor(vec(output(y)), length(a))
     yh = A * a
     oftype(output(y), yh)
 end

--- a/src/arx.jl
+++ b/src/arx.jl
@@ -891,23 +891,23 @@ end
     a,b = params2poly2(params,na,nb; inputdelay = ones(Int, size(nb)))
 Used to get numerator and denominator polynomials after arx fitting. Updated version supporting a direct term.
 """
-function params2poly2(w, na, nb; inputdelay = ones(Int, size(nb)))
+function params2poly2(w::AbstractVector{T}, na, nb; inputdelay = ones(Int, size(nb))) where T
     maxb = maximum(nb .+ inputdelay)
-    a = [1; -w[1:na]]
-    a = [a; zeros(max(0, maxb - na -1))] # if nb > na
+    a = [one(T); -w[1:na]]
+    a = [a; zeros(T, max(0, maxb - na -1))] # if nb > na
     w = w[na+1:end]
     b = map(1:length(nb)) do i
         b = w[1:nb[i]]
         w = w[nb[i]+1:end]
-        b = [zeros(inputdelay[i]); b; zeros(max(na+1, maxb) - inputdelay[i] - nb[i])] # compensate for different nbs and delay, as well as na > nb
+        b = [zeros(T, inputdelay[i]); b; zeros(T, max(na+1, maxb) - inputdelay[i] - nb[i])] # compensate for different nbs and delay, as well as na > nb
         b
     end
     return a, b
 end
 
-function params2poly(w, na)
-    a = [1; -w]
-    b = [1; zeros(na)]
+function params2poly(w::AbstractVector{T}, na) where T
+    a = [one(1); -w]
+    b = [one(1); zeros(T, na)]
     return a, b
 end
 

--- a/src/frd.jl
+++ b/src/frd.jl
@@ -173,7 +173,7 @@ N: Noise model
 function coherence(d; n = length(d) ÷ 10, noverlap = n ÷ 2, window = hamming)
     noutputs(d) == 1 || throw(ArgumentError("coherence only supports a single output. Index the data object like `d[i,j]` to obtain the `i`:th output and the `j`:th input."))
     ninputs(d) == 1 || throw(ArgumentError("coherence only supports a single input. Index the data object like `d[i,j]` to obtain the `i`:th output and the `j`:th input."))
-    y, u, h = time1(output(d)), time1(input(d)), sampletime(d)
+    y, u, h = vec(output(d)), vec(input(d)), sampletime(d)
     Syy, Suu, Syu = wcfft(y, u, n = n, noverlap = noverlap, window = window)
     k = (abs2.(Syu) ./ (Suu .* Syy))#[end÷2+1:end]
     Sch = FRD(freqvec(h, k), k)

--- a/src/frd.jl
+++ b/src/frd.jl
@@ -143,7 +143,7 @@ function tfest(d, σ::Real = 0.05)
         NR = reshape(reduce(vcat, [transpose(hn[2].r) for hn in HNs]), d.ny, 1, :)
         return FRD(HNs[1][1].w, HR), FRD(HNs[1][1].w, NR)
     end
-    y, u, h = time1(output(d)), time1(input(d)), sampletime(d)
+    y, u, h = vec(output(d)), vec(input(d)), sampletime(d)
     Syy, Suu, Syu = fft_corr(y, u, σ)
     w = freqvec(h, Syu)
     H = FRD(w, Syu ./ Suu)

--- a/src/frequency_weights.jl
+++ b/src/frequency_weights.jl
@@ -13,23 +13,23 @@ function frequency_weight(system, N)
     n = length(acf)
 
 
-    lastlarge = findlast(x -> abs(x) > sqrt(eps()) * acf[1], acf)
-    if lastlarge === nothing || lastlarge == n
-        lastlarge = n - 1
-    end
-    bands = [0 => Fill(acf[1], n)]
-    for i = 1:lastlarge
-        slice = Fill(acf[i+1], n - i)
-        push!(bands, i => slice)
-        push!(bands, -i => slice)
-    end
-    W = BandedMatrix((bands...,), (n, n))
-
-    # W = similar(acf, n, n)
-    # for di = -n+1:n-1
-    #     W[diagind(W,di)] .= acf[abs(di)+1]
+    # lastlarge = findlast(x -> abs(x) > sqrt(eps()) * acf[1], acf)
+    # if lastlarge === nothing || lastlarge == n
+    #     lastlarge = n - 1
     # end
-    # Symmetric(W)
+    # bands = [0 => Fill(acf[1], n)]
+    # for i = 1:lastlarge
+    #     slice = Fill(acf[i+1], n - i)
+    #     push!(bands, i => slice)
+    #     push!(bands, -i => slice)
+    # end
+    # W = BandedMatrix((bands...,), (n, n))
+
+    W = similar(acf, n, n)
+    for di = -n+1:n-1
+        W[diagind(W,di)] .= acf[abs(di)+1]
+    end
+    Symmetric(W)
 end
 
 weighted_estimator(H::FilterType) = (A, y) -> wls(A, y, frequency_weight(H, size(y, 1)))

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -331,7 +331,8 @@ Plots the RMSE and AIC For model orders up to `n`. Useful for model selection
 find_na
 @recipe function find_na(p::Find_na)
     y, n = p.args[1:2]
-    y = time1(y)
+    size(y, 1) == 1 || size(y, 2) == 1 || throw(ArgumentError("Only one-dimensional time series supported."))
+    y = vec(y)
     error = zeros(n, 2)
     for i = 1:n
         yt, A = getARXregressor(y, 0y, i, 0)
@@ -355,7 +356,8 @@ Plots the RMSE and AIC For model orders up to `n`. Useful for model selection
 find_nanb
 @recipe function find_nanb(p::Find_nanb; logrms = false)
     d, na, nb = p.args[1:3]
-    y, u = time1(output(d)), time1(input(d))
+    d.ny == 1 || throw(ArgumentError("Only one-dimensional outputs supported."))
+    y, u = vec(output(d)), time1(input(d))
     error = zeros(na, nb, 2)
     for i = 1:na, j = 1:nb
         yt, A = getARXregressor(y, u, i, j)

--- a/src/types.jl
+++ b/src/types.jl
@@ -149,10 +149,10 @@ hasinput(::OutputData)                           = false
 hasinput(::AbstractIdData)                       = true
 hasinput(::AbstractArray)                        = true
 hasinput(::ControlSystems.LTISystem)             = true
-ControlSystems.noutputs(d::AbstractIdData)       = obslength(d.y)
-ControlSystems.ninputs(d::AbstractIdData)        = hasinput(d) ? obslength(d.u) : 0
+ControlSystems.noutputs(d::AbstractIdData)       = obslength(getfield(d, :y))
+ControlSystems.ninputs(d::AbstractIdData)        = hasinput(d) ? obslength(getfield(d, :u)) : 0
 ControlSystems.nstates(d::AbstractIdData)        = 0
-ControlSystems.nstates(d::InputOutputStateData)  = obslength(d.x)
+ControlSystems.nstates(d::InputOutputStateData)  = obslength(getfield(d, :x))
 obslength(d::AbstractIdData)                     = ControlSystems.noutputs(d)
 sampletime(d::AbstractIdData)                    = d.Ts === nothing ? 1.0 : d.Ts
 function Base.length(d::AbstractIdData)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -47,6 +47,9 @@ end
 @inline function time1(y::AbstractMatrix)
     Matrix(transpose(y))
 end
+@inline function time1(y::Union{Adjoint{T, Vector{T}}, Transpose{T, Vector{T}}}) where T
+    transpose(y)
+end
 
 @inline time2(y::Vector) = oftype(Matrix, y)
 @inline time2(y::Vector{<:Vector}) = oftype(Matrix, y)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,15 +42,9 @@ end
 @inline time1(y::Vector) = y
 @inline time1(y::Vector{<:Vector}) = transpose(reduce(hcat, y))
 @inline function time1(y::Matrix)
-    if size(y, 1) == 1
-        return vec(y)
-    end
     Matrix(transpose(y))
 end
 @inline function time1(y::AbstractMatrix)
-    if size(y, 1) == 1
-        return vec(y)
-    end
     Matrix(transpose(y))
 end
 

--- a/test/test_frequency_weights.jl
+++ b/test/test_frequency_weights.jl
@@ -85,4 +85,4 @@ Gf2 = Gf2.sys
 @test freqresptest(G1, Gf1) < 1
 @test freqresptest(G2, Gf2) < 1
 
-# isinteractive() && bodeplot([G1, G2, Gf1, Gf2], ωvec, plotphase=false, lab=["G1" "G2" "Focus f1" "Focus f2"])
+isinteractive() && bodeplot([G1, G2, Gf1, Gf2], ωvec, plotphase=false, lab=["G1" "G2" "Focus f1" "Focus f2"])


### PR DESCRIPTION
some simple type-stability improvements takes
```julia
julia> @time subspaceid(d, 2);
 13.317923 seconds (48.73 M allocations: 2.806 GiB, 8.91% gc time, 99.96% compilation time)
```
to
```julia
 9.236199 seconds (27.19 M allocations: 1.325 GiB, 12.12% gc time, 99.98% compilation time)
```



```julia
  julia> @time tfest(d);
  7.411997 seconds (25.10 M allocations: 1.631 GiB, 8.98% gc time, 99.96% compilation time) # before
  3.793959 seconds (14.25 M allocations: 944.387 MiB, 8.01% gc time, 99.93% compilation time) # after
```