### PR TITLE
Use tridiagonal parametrization in newpem

### DIFF
--- a/src/pem.jl
+++ b/src/pem.jl
@@ -297,12 +297,17 @@ trivec(A) = [A[diagind(A, -1)]; A[diagind(A, 0)]; A[diagind(A, 1)]]
 
 
 function vec2modal(p, ny, nu, nx, timeevol, zeroD, pred, D0, K0)
-    al = (1:nx-1)
-    a  = (1:nx) .+ al[end]
-    au = (1:nx-1) .+ a[end]
+    if nx > 1
+        al = (1:nx-1)
+        a  = (1:nx) .+ al[end]
+        au = (1:nx-1) .+ a[end]
+        A = Matrix(Tridiagonal(p[al], p[a], p[au]))
+    else
+        A = [p[1];;]
+        au = 1:1
+    end
     bi = (1:nx*nu) .+ au[end]
     ci = (1:nx*ny) .+ bi[end]
-    A = Tridiagonal(p[al], p[a], p[au])
     B = reshape(p[bi], nx, nu)
     C = reshape(p[ci], ny, nx)
     if zeroD

--- a/src/types.jl
+++ b/src/types.jl
@@ -356,12 +356,12 @@ ramp_out(d::InputOutputData, h::Int) = ramp_in(d,h; rev=true)
 
 abstract type AbstractPredictionStateSpace{T} <: AbstractStateSpace{T} end
 
-Base.@kwdef struct PredictionStateSpace{T} <: AbstractPredictionStateSpace{T}
+struct PredictionStateSpace{T, ST <: AbstractStateSpace{T}, KT, QT, RT} <: AbstractPredictionStateSpace{T}
 # has at least K, but perhaps also covariance matrices? Would be nice in order to be able to resample he system. Can be nothing in case they are not known
-    sys::AbstractStateSpace{T}
-    K
-    Q = nothing
-    R = nothing
+    sys::ST
+    K::KT
+    Q::QT
+    R::RT
 end
 
 Base.promote_rule(::Type{AbstractStateSpace{T}}, ::Type{<:AbstractPredictionStateSpace{T}}) where T<:ControlSystems.TimeEvolution  = StateSpace{T<:ControlSystems.TimeEvolution}
@@ -394,21 +394,21 @@ The result of statespace model estimation using the `n4sid` method.
 - `s`: singular values
 - `fve`: Fraction of variance explained by singular values
 """
-struct N4SIDStateSpace <: AbstractPredictionStateSpace{Discrete{Float64}}
-    sys::Any
-    Q::Any
-    R::Any
-    S::Any
-    K::Any
-    P::Any
-    x::Any
-    s::Any
-    fve::Any
+struct N4SIDStateSpace{Tsys,TQ,TR,TS,TK,TP,Tx,Ts,Tfve} <: AbstractPredictionStateSpace{Discrete{Float64}}
+    sys::Tsys
+    Q::TQ
+    R::TR
+    S::TS
+    K::TK
+    P::TP
+    x::Tx
+    s::Ts
+    fve::Tfve
 end
 
 @inline function Base.getproperty(res::AbstractPredictionStateSpace, p::Symbol)
     if p ∈ (:A, :B, :C, :D, :nx, :ny, :nu, :Ts, :timeevol)
-        return getproperty(res.sys, p)
+        return getproperty(getfield(res, :sys), p)
     end
     return getfield(res, p)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,14 +108,17 @@ end
     end
 
     @testset "pem" begin
+        @info "Testing pem"
         include("test_pem.jl")
     end
 
     @testset "arx" begin
+        @info "Testing arx"
         include("test_arx.jl")
     end
 
     @testset "ar" begin
+        @info "Testing ar"
         include("test_ar.jl")
     end
 


### PR DESCRIPTION
An `A`-matrix on tridiagonal form reduces the number of parameters while keeping the optimization landscape well behaved