### PR TITLE
add option to penalize curvature in `okid` impulse response

### DIFF
--- a/docs/src/ss.md
+++ b/docs/src/ss.md
@@ -74,11 +74,13 @@ ds = map(1:5) do i
     iddata(yn, u, Ts)
 end
 
-Ys = okid.(ds, 2, round(Int, 10/Ts))    # Estimate impulse response for each experiment
+Ys = okid.(ds, 2, round(Int, 10/Ts), smooth=true, λ=1)    # Estimate impulse response for each experiment
 Y = mean(Ys)                            # Average all impulse responses
 
-f1 = plot(vec.(Ys), lab="Individual estimates", title="Impulse-response estimates")
-plot!(vec(Y), l=(3, :black), lab="Mean")
+imp = impulse(G, 10)
+f1 = plot(imp, lab="True", l=5)
+plot!(imp.t, vec.(Ys), lab="Individual estimates", title="Impulse-response estimates")
+plot!(imp.t, vec(Y), l=(3, :black), lab="Mean")
 
 models = era.(Ys, Ts, 2, 50, 50)    # estimate models based on individual experiments
 meanmodel = era(Y, Ts, 2, 50, 50)   # estimate model based on mean impulse response
@@ -89,9 +91,9 @@ bodeplot!(models, lab="Individual estimates", c=:black, alpha=0.5, legend=:botto
 plot(f1, f2)
 ```
 
-The procedure shown above is equivalent to calling [`era`](@ref) directly with a vector of data sets, in which case the averaging of the impluse responses is done internally.
+The procedure shown above is equivalent to calling [`era`](@ref) directly with a vector of data sets, in which case the averaging of the impulse responses is done internally.
 ```@example ss
-era(ds, 2, 50, 50, round(Int, 10/Ts), p=1) # Should be identical to meanmodel above
+era(ds, 2, 50, 50, round(Int, 10/Ts), p=1, λ=1, smooth=true) # Should be identical to meanmodel above
 ```
 
 

--- a/src/subspace.jl
+++ b/src/subspace.jl
@@ -342,6 +342,9 @@ function era(YY::AbstractArray{<:Any,3}, Ts, r::Int, m::Int = 2r, n::Int = 2r)
     Ar = S2 * Ur'H2 * Vr * S2
     Br = S2 * Ur'H[:, 1:nin]
     Cr = H[1:nout, :] * Vr * S2
+    if Ts !== nothing
+        Br .*= Ts # Scale to match scaling in okid for match between discrete and continuous impulse responses
+    end
     ss(Ar, Br, Cr, Dr, Ts === nothing ? 1 : Ts)
 end
 
@@ -385,11 +388,13 @@ The parameter `l` is likely to require tuning, a reasonable starting point to ch
 - `nx`: Model order
 - `l`: Number of Markov parameters to estimate (length of impulse response).
 - `λ`: Regularization parameter
+- `smooth`: If true, the regularization given by `λ` penalizes curvature in the estimated impulse response. If [`era`](@ref) is to be used after `okid`, favor a small `λ` with `smooth=true`, but if the impulse response is to be inspected by eye, a larger smoothing can yield a visually more accurate estimate of the impulse response.
 - `p`: Optionally, delete the first `p` columns in the internal Hankel matrices to account for initial conditions != 0. If `x0 != 0`, try setting `p` around the same value as `l`.
 - `estimator`: Function to use for estimating the Markov parameters. Defaults to `/` (least squares), but can also be a robust option such as `TotalLeastSquares.irls / flts` or `TotalLeastSquares.tls` for a total least-squares solutoins (errors in variables).
 """
-@views function okid(d::AbstractIdData, nx, l = 5nx; λ = 0.0, p::Int = 1, estimator = /)
+@views function okid(d::AbstractIdData, nx, l = 5nx; λ = 0.0, smooth=false, p::Int = 1, estimator = /)
     y, u = time2(output(d)), time2(input(d))
+    Ts = d.Ts
     q, N = size(y) # p is the number of outputs
     m = size(u, 1) # q is the number of inputs
     # Step 2, form y, V, solve for observer Markov params, Ȳ
@@ -408,7 +413,15 @@ The parameter `l` is likely to require tuning, a reasonable starting point to ch
         y = y[:, p+1:end]
     end
     if λ > 0
-        Ȳ = estimator([y zeros(size(y, 1), size(V, 1))], [V λ * I])
+        if smooth
+            n = size(V, 1)
+            Λ = (λ / Ts^2) * diagm(-1=>ones(n-1), 0=>-2ones(n), 1=>ones(n-1))
+            Λ[1,:] .= 0
+            Λ[end,:] .= 0
+            Ȳ = estimator([y zeros(size(y, 1), size(V, 1))], [V Λ'])
+        else
+            Ȳ = estimator([y zeros(size(y, 1), size(V, 1))], [V λ * I])
+        end
     else
         Ȳ = estimator(y, V)
     end
@@ -436,5 +449,6 @@ The parameter `l` is likely to require tuning, a reasonable starting point to ch
     for k = 2:l+1
         H[:, :, k] = Y[:, :, k-1]
     end
+    H ./= Ts # Scale to match continuous-time response
     H
 end

--- a/src/subspace.jl
+++ b/src/subspace.jl
@@ -449,6 +449,8 @@ The parameter `l` is likely to require tuning, a reasonable starting point to ch
     for k = 2:l+1
         H[:, :, k] = Y[:, :, k-1]
     end
-    H ./= Ts # Scale to match continuous-time response
+    if Ts !== nothing && !iszero(Ts)
+        H ./= Ts # Scale to match continuous-time response
+    end
     H
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,6 +161,7 @@ end
 
     @testset "sampling of covariance matrices" begin
         @info "Testing sampling of covariance matrices"
+        Random.seed!(1)
         N = 200
         r = 2
         m = 2

--- a/test/test_subspace.jl
+++ b/test/test_subspace.jl
@@ -6,8 +6,8 @@ freqresptest(G, model) =
 
 freqresptest(G, model, tol) = freqresptest(G, model) < tol
 
-@testset "n4sid" begin
-    @info "Testing n4sid"
+@testset "n4sid and era/okid" begin
+    @info "Testing n4sid and era/okid"
 
 
     N = 500


### PR DESCRIPTION
also apply scaling of the estimated response with the sample time in order to match continuous-time response