### PR TITLE
return empty input for `OutputData`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -163,6 +163,7 @@ iddata(res::ControlSystemsBase.SimResult) = iddata(res.y, res.u, res.t[2]-res.t[
 
 output(d::AbstractIdData)                        = d.y
 input(d::AbstractIdData)                         = d.u
+input(d::OutputData)                             = fill(eltype(d.y)[], length(d)) # Return empty input array
 LowLevelParticleFilters.state(d::AbstractIdData) = d.x
 output(d::AbstractArray)                         = d
 input(d::AbstractArray)                          = d

--- a/test/test_iddata.jl
+++ b/test/test_iddata.jl
@@ -7,6 +7,7 @@ using ControlSystemIdentification: Sec
     @test d isa ControlSystemIdentification.OutputData
     @test length(d) == T
     @test output(d) == y
+    @test length(input(d)) == T
     @test !hasinput(d)
     @test ControlSystemIdentification.time2(y) == y
     @test sampletime(d) == 1


### PR DESCRIPTION
this allows it to be used for nonlinear estimation with no inputs