### PR TITLE
add experimental covariance estimate to `structured_pem`

### DIFF
--- a/ext/ControlSystemIdentificationLSOptExt.jl
+++ b/ext/ControlSystemIdentificationLSOptExt.jl
@@ -177,7 +177,8 @@ function _inner_pem(
     function Λ()
         resid = zeros(T * ny)
         J = ForwardDiff.jacobian(residuals!, resid, res.minimizer)
-        (T - length(p_guess)) * Symmetric(J' * J)
+        σ2 = sum(abs2, resid) / (T * ny - length(p_guess))
+        1/σ2 * Symmetric(J' * J)
     end
 
     ukf = get_ukf(res.minimizer)

--- a/ext/ControlSystemIdentificationLSOptExt.jl
+++ b/ext/ControlSystemIdentificationLSOptExt.jl
@@ -177,8 +177,13 @@ function _inner_pem(
     function Λ()
         resid = zeros(T * ny)
         J = ForwardDiff.jacobian(residuals!, resid, res.minimizer)
-        σ2 = sum(abs2, resid) / (T * ny - length(p_guess))
-        1/σ2 * Symmetric(J' * J)
+        Σ = sum(abs2, reshape(resid, ny, T), dims=2)[:] ./ (T - length(p_guess))
+        inds = range(1, step=ny, length=T)
+        for i = 1:ny
+            J[inds, :] ./= sqrt(Σ[i])
+            inds = inds .+ 1
+        end
+        Symmetric(J' * J)
     end
 
     ukf = get_ukf(res.minimizer)

--- a/src/pem.jl
+++ b/src/pem.jl
@@ -780,6 +780,7 @@ function structured_pem(
     function Λ()
         cost = pred ? predloss : simloss
         H = Symmetric(ForwardDiff.hessian(cost, res.minimizer))
+        # NOTE: this scales all gradients by the same σ unlike in nonlinear_pem where we compute a unique σ for each output
         iσ2 = (length(d) - length(res.minimizer))/cost(res.minimizer)
         iσ2 * H
     end

--- a/test/test_nonlinear_pem.jl
+++ b/test/test_nonlinear_pem.jl
@@ -81,12 +81,16 @@ eopt = norm(x0 - model.x0) / norm(x0)
 @test eopt < e0
 
 
+y_err = 2sqrt.(diag(Σ[1:4, 1:4]))
 
 if isinteractive()
-    scatter(p_opt, yerror=2sqrt.(diag(Σ[1:4, 1:4])), lab="Estimate")
+    scatter(p_opt, yerror=y_err, lab="Estimate")
     scatter!(p_true, lab="True")
     scatter!(p0, lab="Initial guess")
 end
+
+z_score = abs.((p_opt - p_true) ./ y_err)
+@test all(z_score .< 3) # All parameters should be within 3 standard deviations
 
 ysim = simulate(model, U)
 ypred = predict(model, d, model.x0)


### PR DESCRIPTION
Usage (experimental)
```julia
using ControlSystemIdentification, Optim, ControlSystemsBase
import LowLevelParticleFilters: SimpleMvNormal
using MonteCarloMeasurements
using Random, Test, LinearAlgebra

constructor = function (p)
    Mα, Mq, Mδe, Zα, Zq, Zδe = p
    V = 30.2
    A = [
        Mq Mα
        (1+Zq / V) Zα/V
    ]
    B = [Mδe; Zδe / V]
    return ss(A, B, I, 0)
end

# True Parameters
Mα_true = -83.17457223750834
Mq_true = -4.0485957994781785
Mδe_true = -80.71377329163104
Zα_true = -115.91677356408941
Zq_true = -0.573560626095269
Zδe_true = 32.13261325199936

Ts = 0.01
t = 0:Ts:10

p_true = [Mα_true, Mq_true, Mδe_true, Zα_true, Zq_true, Zδe_true]
p0 = [Mα_true, Mq_true, Mδe_true, Zα_true, Zq_true, Zδe_true] .* 1.2

P_true = constructor(p_true)
u = sign.(sin.((1 / 3 * t)')) .+ sign.(sin.((1 / 2 * t)'))
res_true = lsim(c2d(P_true, Ts, :tustin), u, t)
d = iddata(res_true)

nx = 2
function regularizer(p, _)
    sum(abs2, p.K)
end

d2 = deepcopy(d)
d2.y .+= randn.()

res = ControlSystemIdentification.structured_pem(d2, nx; focus=:simulation, p0, constructor, regularizer, show_trace = false, show_every = 1, iterations=300, method=:tustin)

H = res.Λ() # Inverse covariance matrix
Σ = inv(H) # Covariance matrix
dp = SimpleMvNormal(res.res.minimizer, Σ) # Parameter posterior distribution
pars = Particles(rand!(Xoshiro(), dp, zeros(length(dp), 100))') # Sample uncertain parameters
sysu, Ku, x0u = res.constructor(pars) # Construct uncertain system

w = exp10.(LinRange(-3, 2, 200))
unsafe_comparisons(true)
bodeplot(sysu, w, plotphase=false)
bodeplot!(res.sys, w, plotphase=false, legend=false)
```
![image](https://github.com/user-attachments/assets/b7067662-0f82-4551-a3d8-e1d18b9bc546)

